### PR TITLE
Fix homeassistant_config schema

### DIFF
--- a/SomfyProtect2MQTT/config.json
+++ b/SomfyProtect2MQTT/config.json
@@ -13,11 +13,6 @@
       "password": "iliketurtles",
       "sites": ["Maison"]
     },
-    "homeassistant_config": {
-      "code": "int?",
-      "code_arm_required": "bool",
-      "code_disarm_required": "bool"
-    },
     "mqtt": {
       "host": "192.168.x.x",
       "port": 1883,
@@ -36,6 +31,11 @@
       "username": "str",
       "password": "str",
       "sites": ["str"]
+    },
+    "homeassistant_config": {
+      "code": "int?",
+      "code_arm_required": "bool",
+      "code_disarm_required": "bool"
     },
     "mqtt": {
       "host": "str",


### PR DESCRIPTION
Momentanory  Fix to make the add-on work with code.

_____

Need to deal with int/str value in schema in the next version I will need your help :-)
Look at my main branch where I try to fix it : https://github.com/Minims/homeassistant-addons/commits/main
I have ti integer everywhere , but still have the error : 

```
21-05-24 19:50:44 ERROR (MainThread) [asyncio] Task exception was never retrieved
future: <Task finished name='Task-9057' coro=<Scheduler._run_task.<locals>._wrap_task() done, defined at /usr/src/supervisor/supervisor/misc/scheduler.py:58> exception=TypeError('an integer is required (got type str)')>
Traceback (most recent call last):
  File "/usr/src/supervisor/supervisor/misc/scheduler.py", line 62, in _wrap_task
    await task.coro_callback()
  File "/usr/src/supervisor/supervisor/misc/tasks.py", line 416, in _watchdog_addon_application
    if addon.in_progress or await addon.watchdog_application():
  File "/usr/src/supervisor/supervisor/addons/addon.py", line 479, in watchdog_application
    return await self.sys_run_in_executor(check_port, self.ip_address, port)
  File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/supervisor/supervisor/utils/__init__.py", line 43, in check_port
    result = sock.connect_ex((str(address), port))
TypeError: an integer is required (got type str)
```